### PR TITLE
Feat/version-numbering

### DIFF
--- a/.changeset/gentle-donuts-cover.md
+++ b/.changeset/gentle-donuts-cover.md
@@ -1,0 +1,12 @@
+---
+"@decentology/hyperverse": patch
+"@decentology/hyperverse-algorand": patch
+"@decentology/hyperverse-algorand-counter": patch
+"@decentology/hyperverse-ethereum": patch
+"@decentology/hyperverse-ethereum-tribes": patch
+"@decentology/hyperverse-flow": patch
+"@decentology/hyperverse-flow-tribes": patch
+"@decentology/hyperverse-storage-skynet": patch
+---
+
+Updated package deps versions for semver

--- a/apps/algorand/web/package.json
+++ b/apps/algorand/web/package.json
@@ -12,11 +12,11 @@
     "next": "12.0.3",
     "react": "17.0.2",
     "react-dom": "17.0.2",
-    "@decentology/hyperverse": "*",
-    "@decentology/hyperverse-flow": "*",
-    "@decentology/hyperverse-db": "*",
-    "@decentology/hyperverse-algorand": "*",
-    "@decentology/hyperverse-algorand-counter": "*"
+    "@decentology/hyperverse": "^1.0.0",
+    "@decentology/hyperverse-flow": "^1.0.0",
+    "@decentology/hyperverse-db": "^1.0.0",
+    "@decentology/hyperverse-algorand": "^1.0.0",
+    "@decentology/hyperverse-algorand-counter": "^1.0.0"
   },
   "devDependencies": {
     "eslint": "7.32.0",

--- a/apps/ethereum/tribes/package.json
+++ b/apps/ethereum/tribes/package.json
@@ -9,9 +9,9 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@decentology/hyperverse": "*",
-    "@decentology/hyperverse-ethereum": "*",
-    "@decentology/hyperverse-ethereum-tribes": "*",
+    "@decentology/hyperverse": "^1.0.0",
+    "@decentology/hyperverse-ethereum": "^1.0.0",
+    "@decentology/hyperverse-ethereum-tribes": "^1.0.0",
     "ethers": "^5.5.2",
     "next": "12.0.7",
     "react": "17.0.2",
@@ -22,7 +22,7 @@
     "skynet-js": "^3.0.2"
   },
   "devDependencies": {
-    "@decentology/config": "*",
+    "@decentology/config": "^1.0.0",
     "@types/node": "17.0.7",
     "@types/react": "17.0.38",
     "eslint": "8.6.0",

--- a/apps/flow/tribes/package.json
+++ b/apps/flow/tribes/package.json
@@ -13,12 +13,12 @@
     "next-transpile-modules": "^9.0.0",
     "react": "17.0.2",
     "react-dom": "17.0.2",
-    "@decentology/hyperverse": "*",
-    "@decentology/hyperverse-flow": "*",
-    "@decentology/hyperverse-flow-tribes": "*"
+    "@decentology/hyperverse": "^1.0.0",
+    "@decentology/hyperverse-flow": "^1.0.0",
+    "@decentology/hyperverse-flow-tribes": "^1.0.0"
   },
   "devDependencies": {
-    "@decentology/config": "*",
+    "@decentology/config": "^1.0.0",
     "@types/node": "17.0.10",
     "@types/react": "17.0.38",
     "eslint": "8.7.0",

--- a/packages/hyperverse-algorand-counter/package.json
+++ b/packages/hyperverse-algorand-counter/package.json
@@ -4,7 +4,7 @@
   "main": "./distribution/index.js",
   "types": "./distribution/index.d.ts",
   "type": "module",
-  "version": "0.1.8",
+  "version": "1.0.8",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -24,13 +24,13 @@
     "react": "^17.0.2"
   },
   "devDependencies": {
-    "@decentology/config": "*",
+    "@decentology/config": "^1.0.0",
     "parcel": "^2.2.1",
     "rimraf": "^3.0.2"
   },
   "dependencies": {
-    "@decentology/hyperverse": "*",
-    "@decentology/hyperverse-algorand": "*",
+    "@decentology/hyperverse": "^1.0.0",
+    "@decentology/hyperverse-algorand": "^1.0.0",
     "algosdk": "^1.12.0"
   }
 }

--- a/packages/hyperverse-algorand/package.json
+++ b/packages/hyperverse-algorand/package.json
@@ -23,11 +23,11 @@
     "access": "public"
   },
   "devDependencies": {
-    "@decentology/config": "*",
+    "@decentology/config": "^1.0.0",
     "parcel": "^2.2.1"
   },
   "dependencies": {
-    "@decentology/hyperverse": "*",
+    "@decentology/hyperverse": "^1.0.0",
     "@json-rpc-tools/utils": "^1.7.6",
     "@walletconnect/client": "^1.7.1",
     "algorand-walletconnect-qrcode-modal": "^1.6.1",

--- a/packages/hyperverse-db/package.json
+++ b/packages/hyperverse-db/package.json
@@ -14,6 +14,6 @@
     "react-use": "^17.3.2"
   },
   "devDependencies": {
-    "@decentology/config": "*"
+    "@decentology/config": "^1.0.0"
   }
 }

--- a/packages/hyperverse-ethereum-starterkit/package.json
+++ b/packages/hyperverse-ethereum-starterkit/package.json
@@ -5,6 +5,6 @@
   "private": true,
   "license": "MIT",
   "dependencies": {
-    "@decentology/hyperverse": "*"
+    "@decentology/hyperverse": "^1.0.0"
   }
 }

--- a/packages/hyperverse-ethereum-tribes/package.json
+++ b/packages/hyperverse-ethereum-tribes/package.json
@@ -21,9 +21,9 @@
     "utils"
   ],
   "dependencies": {
-    "@decentology/hyperverse": "*",
-    "@decentology/hyperverse-ethereum": "*",
-    "@decentology/hyperverse-storage-skynet": "*",
+    "@decentology/hyperverse": "^1.0.0",
+    "@decentology/hyperverse-ethereum": "^1.0.0",
+    "@decentology/hyperverse-storage-skynet": "^1.0.0",
     "@openzeppelin/contracts": "^4.4.2",
     "ethers": "^5.5.3",
     "react-query": "^3.34.7",
@@ -32,7 +32,7 @@
     "unstated-next": "^1.1.0"
   },
   "devDependencies": {
-    "@decentology/config": "*",
+    "@decentology/config": "^1.0.0",
     "@nomiclabs/hardhat-ethers": "^2.0.4",
     "@nomiclabs/hardhat-waffle": "^2.0.2",
     "chai": "^4.3.4",

--- a/packages/hyperverse-ethereum/package.json
+++ b/packages/hyperverse-ethereum/package.json
@@ -19,14 +19,14 @@
     "react": "^17.0.2"
   },
   "dependencies": {
-    "@decentology/hyperverse": "*",
+    "@decentology/hyperverse": "^1.0.0",
     "@walletconnect/web3-provider": "^1.7.1",
     "ethers": "^5.5.3",
     "unstated-next": "^1.1.0",
     "web3modal": "^1.9.5"
   },
   "devDependencies": {
-    "@decentology/config": "*",
+    "@decentology/config": "^1.0.0",
     "parcel": "^2.2.1",
     "rimraf": "^3.0.2"
   }

--- a/packages/hyperverse-flow-tribes/package.json
+++ b/packages/hyperverse-flow-tribes/package.json
@@ -23,14 +23,14 @@
     "react": "^17.0.2"
   },
   "dependencies": {
-    "@decentology/hyperverse": "*",
-    "@decentology/hyperverse-flow": "*",
+    "@decentology/hyperverse": "^1.0.0",
+    "@decentology/hyperverse-flow": "^1.0.0",
     "@onflow/fcl": "^0.0.78",
     "@onflow/types": "^0.0.6",
     "unstated-next": "^1.1.0"
   },
   "devDependencies": {
-    "@decentology/config": "*",
+    "@decentology/config": "^1.0.0",
     "@types/node": "^17.0.16",
     "parcel": "^2.2.1",
     "rimraf": "^3.0.2"

--- a/packages/hyperverse-flow/package.json
+++ b/packages/hyperverse-flow/package.json
@@ -23,13 +23,13 @@
     "react": "^17.0.2"
   },
   "devDependencies": {
-    "@decentology/config": "*",
+    "@decentology/config": "^1.0.0",
     "parcel": "^2.2.1",
     "rimraf": "^3.0.2"
   },
   "dependencies": {
-    "@decentology/hyperverse": "*",
-    "@decentology/hyperverse-storage-skynet": "*",
+    "@decentology/hyperverse": "^1.0.0",
+    "@decentology/hyperverse-storage-skynet": "^1.0.0",
     "@onflow/fcl": "^0.0.77",
     "@onflow/types": "^0.0.5",
     "aphrodite": "^2.4.0",

--- a/packages/hyperverse-storage-skynet/package.json
+++ b/packages/hyperverse-storage-skynet/package.json
@@ -23,7 +23,7 @@
     "react": "^17.0.2"
   },
   "devDependencies": {
-    "@decentology/config": "*",
+    "@decentology/config": "^1.0.0",
     "parcel": "^2.2.1",
     "rimraf": "^3.0.2"
   },

--- a/packages/hyperverse-template/package.json
+++ b/packages/hyperverse-template/package.json
@@ -24,7 +24,7 @@
     "react": "^17.0.2"
   },
   "devDependencies": {
-    "@decentology/config": "*",
+    "@decentology/config": "^1.0.0",
     "parcel": "^2.2.1",
     "rimraf": "^3.0.2"
   },

--- a/packages/hyperverse/package.json
+++ b/packages/hyperverse/package.json
@@ -23,11 +23,11 @@
     "react": "^17.0.2"
   },
   "dependencies": {
-    "@decentology/hyperverse-storage-skynet": "*",
+    "@decentology/hyperverse-storage-skynet": "^1.0.0",
     "unstated-next": "^1.1.0"
   },
   "devDependencies": {
-    "@decentology/config": "*",
+    "@decentology/config": "^1.0.0",
     "parcel": "^2.2.1",
     "rimraf": "^3.0.2"
   }


### PR DESCRIPTION
Setting semver version numbers vs doing * should allow for only importing the hyperverse smart module and pull the latest version of dependencies

* works well inside of the mono repo but not when packages are published